### PR TITLE
Tags can be selected in question-prompt page and seen in user page [#130]

### DIFF
--- a/public/stylesheets/question-prompt.css
+++ b/public/stylesheets/question-prompt.css
@@ -1,0 +1,7 @@
+/* Question prompt page */
+.btn span.glyphicon {    			
+	opacity: 0;				
+}
+.btn.active span.glyphicon {				
+	opacity: 1;				
+}

--- a/public/stylesheets/userpagestyle.css
+++ b/public/stylesheets/userpagestyle.css
@@ -26,3 +26,9 @@ img.profile-icon {
 	width:50%;
 	height:50%;
 }
+
+.tag {
+	padding: 8px;
+	margin: 0px 2px;
+	font-size: 12px;
+}

--- a/views/question-prompt.hbs
+++ b/views/question-prompt.hbs
@@ -13,24 +13,142 @@
     <!-- External CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
     <link rel="stylesheet" href="stylesheets/standardstyle.css">
+    <link rel="stylesheet" href="stylesheets/question-prompt.css">
+
   </head>
   <body>
     {{>header}}
+
     <div class="container" style="margin-top: 50px">
       <div class="page-header">
         <h2>Ask a question <small>Fill all fields</small></h2> 
       </div>
+      <label>Select up to 5 tags (Must select atleast 1)</label>
+    </div>
 
+    <div class="container-fluid">
+      <div class="form-group">
+        <div class="btn-group-wrap text-center">
+          <div class="btn-group" data-toggle="buttons">
+
+            <label class="btn btn-success">
+              <input type="checkbox" autocomplete="off">
+              <span class="glyphicon glyphicon-ok"></span>
+              Java
+            </label>
+
+            <label class="btn btn-primary">
+              <input type="checkbox" autocomplete="off">
+              <span class="glyphicon glyphicon-ok"></span>
+              Php
+            </label>      
+          
+            <label class="btn btn-info">
+              <input type="checkbox" autocomplete="off">
+              <span class="glyphicon glyphicon-ok"></span>
+              Python
+            </label>      
+          
+            <label class="btn btn-default">
+              <input type="checkbox" autocomplete="off">
+              <span class="glyphicon glyphicon-ok"></span>
+              C++
+            </label>      
+
+            <label class="btn btn-warning">
+              <input type="checkbox" autocomplete="off">
+              <span class="glyphicon glyphicon-ok"></span>
+              C#
+            </label>      
+          
+            <label class="btn btn-danger">
+              <input type="checkbox" autocomplete="off">
+              <span class="glyphicon glyphicon-ok"></span>
+              Ruby
+            </label>  
+
+            <label class="btn btn-success">
+              <input type="checkbox" autocomplete="off">
+              <span class="glyphicon glyphicon-ok"></span>
+              Lisp
+            </label>
+
+            <label class="btn btn-primary">
+              <input type="checkbox" autocomplete="off">
+              <span class="glyphicon glyphicon-ok"></span>
+              Prolog
+            </label>      
+          
+            <label class="btn btn-info">
+              <input type="checkbox" autocomplete="off">
+              <span class="glyphicon glyphicon-ok"></span>
+              HTML
+            </label>
+          
+            <label class="btn btn-default">
+              <input type="checkbox" autocomplete="off">
+              <span class="glyphicon glyphicon-ok"></span>
+              CSS
+            </label>      
+
+            <label class="btn btn-warning">
+              <input type="checkbox" autocomplete="off">
+              <span class="glyphicon glyphicon-ok"></span>
+              JavaScript
+            </label>      
+          
+            <label class="btn btn-danger">
+              <input type="checkbox" autocomplete="off">
+              <span class="glyphicon glyphicon-ok"></span>
+              Jade
+            </label>
+
+            <label class="btn btn-success">
+              <input type="checkbox" autocomplete="off">
+              <span class="glyphicon glyphicon-ok"></span>
+              C
+            </label>
+
+            <label class="btn btn-primary">
+              <input type="checkbox" autocomplete="off">
+              <span class="glyphicon glyphicon-ok"></span>
+              Fortran
+            </label>      
+          
+            <label class="btn btn-info">
+              <input type="checkbox" autocomplete="off">
+              <span class="glyphicon glyphicon-ok"></span>
+              Visual Basic
+            </label>      
+          
+            <label class="btn btn-default">
+              <input type="checkbox" autocomplete="off">
+              <span class="glyphicon glyphicon-ok"></span>
+              Assembly
+            </label>      
+
+            <label class="btn btn-warning">
+              <input type="checkbox" autocomplete="off">
+              <span class="glyphicon glyphicon-ok"></span>
+              Perl
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="container">
       <form action="/question-prompt" method="post">
         <div class="form-group">
           <label for="inputsm">Title:</label>
           <input class="form-control" id="title" name="title" type="text">
-        </div>
-
+        </div>     
+        
         <div class="form-group">
           <label for="comment">Question:</label>
           <textarea class="form-control" id="text" name="question" rows="20" type="text"></textarea>
         </div>
+
         <div class="row">
           <input class="btn btn-success" type="submit" value="Submit" onClick="checkFilled()">
           <a href="/"><input class="btn btn-danger" type="button" value="Cancel" onClick="clear()"></a>

--- a/views/question-prompt.hbs
+++ b/views/question-prompt.hbs
@@ -40,7 +40,7 @@
             <label class="btn btn-primary">
               <input type="checkbox" autocomplete="off">
               <span class="glyphicon glyphicon-ok"></span>
-              Php
+              PHP
             </label>      
           
             <label class="btn btn-info">

--- a/views/userRankPage.hbs
+++ b/views/userRankPage.hbs
@@ -24,7 +24,7 @@
         <div class="btn-group-wrap">
           <div class="btn-group">
               <button class="btn btn-success" type="button">Java</button>
-              <button class="btn btn-success" type="button">Php</button>
+              <button class="btn btn-success" type="button">PHP</button>
               <button class="btn btn-success" type="button">Python</button>
               <button class="btn btn-success" type="button">C++</button>
               <button class="btn btn-success" type="button">C#</button>

--- a/views/userpage.hbs
+++ b/views/userpage.hbs
@@ -39,7 +39,7 @@
 
             <span class="label tag label-pill label-primary">
               <span>2</span>
-              <span>Php</span>              
+              <span>PHP</span>              
             </span>      
           
             <span class="label tag label-pill label-info">

--- a/views/userpage.hbs
+++ b/views/userpage.hbs
@@ -25,6 +25,102 @@
       <h2><strong>{{user.username}}</strong></h2>
       <button class="btn btn-info" type="button" onclick="location.href='/edituserpage'">Edit profile</button>
     </div>
+
+    <!-- User tag scores -->
+    <div class="container-fluid">
+      <div class="form-group">
+        <div class="badge-group-wrap text-center">
+          <div class="badge-group" data-toggle="buttons">
+
+            <span class="label tag label-pill label-success">
+              <span>2</span>
+              <span>Java</span>
+            </span>
+
+            <span class="label tag label-pill label-primary">
+              <span>2</span>
+              <span>Php</span>              
+            </span>      
+          
+            <span class="label tag label-pill label-info">
+              <span>2</span>
+              <span>Python</span>              
+            </span>      
+          
+            <span class="label tag label-pill label-default">
+              <span>2</span>
+              <span>C++</span>              
+            </span>      
+
+            <span class="label tag label-pill label-warning">
+              <span>2</span>
+              <span>C#</span>              
+            </span>      
+          
+            <span class="label tag label-pill label-danger">
+              <span>2</span>
+              <span>Ruby</span>              
+            </span>  
+
+            <span class="label tag label-pill label-success">
+              <span>2</span>
+              <span>Lisp</span>              
+            </span>
+
+            <span class="label tag label-pill label-primary">
+              <span>2</span>
+              <span>Prolog</span>              
+            </span>      
+          
+            <span class="label tag label-pill label-info">
+              <span>2</span>
+              <span>HTML</span>              
+            </span>
+          
+            <label class="label tag label-pill label-default">
+              <span>2</span>
+              <span>CSS</span>              
+            </label>      
+
+            <label class="label tag label-pill label-warning">
+              <span>2</span>
+              <span>JavaScript</span>              
+            </label>      
+          
+            <label class="label tag label-pill label-danger">
+              <span>2</span>
+              <span>Jade</span>              
+            </label>
+
+            <label class="label tag label-pill label-success">
+              <span>2</span>
+              <span>C</span>              
+            </label>
+
+            <label class="label tag label-pill label-primary">
+              <span>2</span>
+              <span>Fortran</span> 
+            </label>      
+          
+            <label class="label tag label-pill label-info">
+              <span>2</span>
+              <span>Visual Basic</span>              
+            </label>      
+          
+            <label class="label tag label-pill label-default">
+              <span>2</span>
+              <span>Assembly</span>              
+            </label>      
+
+            <label class="label tag label-pill label-warning">
+              <span>2</span>
+              <span>Perl</span>              
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div class="container">
       <div class="row">
         <div class="col-sm-3 offset-sm-1">


### PR DESCRIPTION
[Task #130]
This pull request consists of the frontend portion of the tag implementation for the question prompt and user page. Tags can now be selected in the question-prompt page when create a question. Multiple tags can be selected and the selected tags will be added to the question data once backend portion of tags is complete. User's tag scores are now visible on the user page and once backend portion of tags is complete, the appropriate scores will be retrieved from the database. 